### PR TITLE
Correct param types.

### DIFF
--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -16,8 +16,8 @@ const KMS_MODULE = 'ssm-v1';
  *
  *
  * @param {string} accountId - Id of the account to associate with the Profile.
- * @param {object} [didMethod] - Supported: 'key' and 'v1'.
- * @param {string} [didOptions] - Hashmap of optional DID method options.
+ * @param {string} [didMethod] - Supported: 'key' and 'v1'.
+ * @param {object} [didOptions] - Hashmap of optional DID method options.
  *
  * @return {Promise<Profile>} resolves to a profile's settings.
  */


### PR DESCRIPTION
When logging out the `didMethod` and `didOptions` when creating a profile, it appears the types were swapped.

{
  account: 'urn:uuid:123',
  didMethod: 'v1',
  didOptions: { mode: 'test' }
}