### PR TITLE
Use KeystoreAgent to update keystore configs.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
     'digitalbazaar',
     'digitalbazaar/jsdoc',
   ],
+  parserOptions: {
+    ecmaVersion: 2020,
+  },
   root: true,
   ignorePatterns: ['node_modules/']
 };

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   test-node:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       mongodb:
         image: mongo:4.2
@@ -12,7 +13,7 @@ jobs:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -26,10 +27,9 @@ jobs:
       run: |
         cd test
         npm test
-      env:
-        CI: true
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [14.x]
@@ -45,6 +45,7 @@ jobs:
   coverage:
     needs: [test-node]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       mongodb:
         image: mongo:4.2
@@ -66,8 +67,6 @@ jobs:
       run: |
         cd test
         npm run coverage-ci
-      env:
-        CI: true
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 9.0.0 - TBD
 
 ### Changed
+- **BREAKING**: Drop support for Node.js < 14.
 - **BREAKING**: Update to latest KMS keystore config data model. The data model
   no longer includes `invoker` or `delegator`.
 - Use `KeystoreAgent` to update keystore configs vs using the `bedrock-kms` API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock-profile ChangeLog
 
+### 9.0.0 - TBD
+
+### Changed
+- **BREAKING**: Update to latest KMS keystore config data model. The data model
+  no longer includes `invoker` or `delegator`.
+- Use `KeystoreAgent` to update keystore configs vs using the `bedrock-kms` API
+  directly.
+
 ### 8.0.0 - 2020-12-11
 
 ### Added

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+require('bedrock-https-agent');
+
 // NOTE: if the config sets config parameters for other bedrock modules,
 // those modules should be required here
 require('./config');

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -4,8 +4,7 @@
 'use strict';
 
 const bedrock = require('bedrock');
-const {keystores} = require('bedrock-kms');
-const brHttpsAgent = require('bedrock-https-agent');
+const {httpsAgent} = require('bedrock-https-agent');
 const {
   AsymmetricKey,
   Hmac,
@@ -14,7 +13,7 @@ const {
   KeyAgreementKey,
   KmsClient
 } = require('webkms-client');
-const {util: {BedrockError}} = bedrock;
+const {util: {clone, BedrockError}} = bedrock;
 
 exports.createKeystore = async ({
   capabilityAgent, kmsBaseUrl, referenceId
@@ -23,15 +22,10 @@ exports.createKeystore = async ({
   const config = {
     sequence: 0,
     controller: capabilityAgent.id,
-    // TODO: prefer using just controller when the invoker and delegator will be
-    //       the same
-    invoker: capabilityAgent.id,
-    delegator: capabilityAgent.id
   };
   if(referenceId) {
     config.referenceId = referenceId;
   }
-  const {httpsAgent} = brHttpsAgent;
   return KmsClient.createKeystore({
     url: `${kmsBaseUrl}/keystores`,
     config,
@@ -39,46 +33,48 @@ exports.createKeystore = async ({
   });
 };
 
-// FIXME: this only works with an integrated KMS right now and that needs to be
-//        fixed in the future
-exports.updateKeystoreController = async ({id, controller} = {}) => {
-  const {httpsAgent} = brHttpsAgent;
-  const config = await KmsClient.getKeystore({id, httpsAgent});
-
-  const {invoker} = config;
-  if(!Array.isArray(invoker)) {
-    config.invoker = [invoker];
+exports.updateKeystoreController = async ({
+  controller, keystoreAgent, keystoreConfig
+} = {}) => {
+  // if the keystore config is not supplied, retrieve it now
+  if(!keystoreConfig) {
+    // FIXME: GET ID
+    // keystoreConfig = await KmsClient.getKeystore({id, httpsAgent});
+  } else {
+    keystoreConfig = clone(keystoreConfig);
   }
 
   // update config
-  config.sequence++;
-  const {controller: oldController} = config;
-  config.controller = controller;
-  // replace existing controller with new one
-  config.invoker = config.invoker.map(
-    x => x === oldController ? controller : x);
-  if(Array.isArray(config.delegator)) {
-    config.delegator = config.delegator.map(
-      x => x === oldController ? controller : x);
-  } else if(config.delegator === oldController) {
-    config.delegator = controller;
+  keystoreConfig.sequence++;
+  keystoreConfig.controller = controller;
+
+  // FIXME: keep referenceId?
+  delete keystoreConfig.referenceId;
+
+  let err;
+  let result;
+  try {
+    result = await keystoreAgent.updateConfig({config: keystoreConfig});
+  } catch(e) {
+    err = e;
   }
-  const updated = await keystores.update({config});
-  if(!updated) {
+  if(!result?.success) {
     throw new BedrockError(
       'Failed to update keystore with new controller.',
-      'InvalidStateError');
+      'InvalidStateError', {
+        httpStatusCode: 400,
+        public: true,
+      }, err);
   }
-  return config;
+
+  return result.config;
 };
 
 exports.getKeystore = async ({id} = {}) => {
-  const {httpsAgent} = brHttpsAgent;
   return KmsClient.getKeystore({id, httpsAgent});
 };
 
 exports.getKeystoreAgent = ({capabilityAgent, keystore} = {}) => {
-  const {httpsAgent} = brHttpsAgent;
   const kmsClient = new KmsClient({keystore, httpsAgent});
   const keystoreAgent = new KeystoreAgent(
     {keystore, capabilityAgent, kmsClient});

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -33,20 +33,11 @@ exports.createKeystore = async ({
   });
 };
 
-exports.updateKeystoreController = async ({
-  controller, keystoreAgent, keystoreConfig
-} = {}) => {
-  // if the keystore config is not supplied, retrieve it now
-  if(!keystoreConfig) {
-    // FIXME: GET ID
-    // keystoreConfig = await KmsClient.getKeystore({id, httpsAgent});
-  } else {
-    keystoreConfig = clone(keystoreConfig);
-  }
+exports.updateKeystoreConfig = async ({keystoreAgent, keystoreConfig}) => {
+  keystoreConfig = clone(keystoreConfig);
 
-  // update config
+  // update config sequence
   keystoreConfig.sequence++;
-  keystoreConfig.controller = controller;
 
   let result;
   try {

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -48,9 +48,6 @@ exports.updateKeystoreController = async ({
   keystoreConfig.sequence++;
   keystoreConfig.controller = controller;
 
-  // FIXME: keep referenceId?
-  delete keystoreConfig.referenceId;
-
   let err;
   let result;
   try {

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -48,14 +48,10 @@ exports.updateKeystoreController = async ({
   keystoreConfig.sequence++;
   keystoreConfig.controller = controller;
 
-  let err;
   let result;
   try {
     result = await keystoreAgent.updateConfig({config: keystoreConfig});
-  } catch(e) {
-    err = e;
-  }
-  if(!result?.success) {
+  } catch(err) {
     throw new BedrockError(
       'Failed to update keystore with new controller.',
       'InvalidStateError', {

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -84,8 +84,9 @@ module.exports.create = async ({
   // DID#KEY_IDENTIFIER
   const profileDid = key.id.split('#')[0];
   await kms.updateKeystoreController({
-    id: profileKeystore.id,
-    controller: profileDid
+    controller: profileDid,
+    keystoreAgent: profileKeystoreAgent,
+    keystoreConfig: profileKeystore,
   });
   await profileAgents.update({
     profileAgent: {
@@ -97,5 +98,6 @@ module.exports.create = async ({
       }
     }
   });
+
   return {id: profileDid};
 };

--- a/lib/profiles.js
+++ b/lib/profiles.js
@@ -83,8 +83,8 @@ module.exports.create = async ({
   // Assuming structure of did:key and did:v1 key identifiers to be:
   // DID#KEY_IDENTIFIER
   const profileDid = key.id.split('#')[0];
-  await kms.updateKeystoreController({
-    controller: profileDid,
+  profileKeystore.controller = profileDid;
+  await kms.updateKeystoreConfig({
     keystoreAgent: profileKeystoreAgent,
     keystoreConfig: profileKeystore,
   });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "express-async-handler": "^1.1.4",
     "jsonld-signatures": "^5.1.0",
     "ocapld": "^2.0.0",
-    "webkms-client": "^2.3.0"
+    "webkms-client": "digitalbazaar/webkms-client#update-keystore"
   },
   "peerDependencies": {
     "bedrock": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "webkms-client": "^2.5.0"
   },
   "peerDependencies": {
-    "bedrock": "^3.1.1",
+    "bedrock": "^4.1.1",
     "bedrock-edv-storage": "^4.1.1",
     "bedrock-https-agent": "^2.0.0",
     "bedrock-mongodb": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "eslint": "^7.4.0",
     "eslint-config-digitalbazaar": "^2.5.0",
     "eslint-plugin-jsdoc": "^30.3.1"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "express-async-handler": "^1.1.4",
     "jsonld-signatures": "^5.1.0",
     "ocapld": "^2.0.0",
-    "webkms-client": "digitalbazaar/webkms-client#update-keystore"
+    "webkms-client": "^2.5.0"
   },
   "peerDependencies": {
     "bedrock": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -24,15 +24,11 @@
   "homepage": "https://github.com/digitalbazaar/bedrock-profile",
   "dependencies": {
     "assert-plus": "^1.0.0",
-    "axios": "^0.19.2",
     "base64url-universal": "^1.1.0",
-    "bs58": "^4.0.1",
-    "cors": "^2.8.5",
     "crypto-ld": "^3.7.0",
     "did-method-key": "^0.7.0",
     "did-veres-one": "^12.1.1",
     "edv-client": "^6.0.1",
-    "express-async-handler": "^1.1.4",
     "jsonld-signatures": "^5.1.0",
     "ocapld": "^2.0.0",
     "webkms-client": "^2.5.0"

--- a/test/mocha/20-profiles.js
+++ b/test/mocha/20-profiles.js
@@ -80,8 +80,9 @@ describe('profiles API', () => {
       agents.should.have.length(1);
       const [a] = agents;
       a.should.have.keys(['_id', 'id', 'controller', 'meta', 'config']);
+      // FIXME: keeping referenceId?
       a.config.should.have.keys([
-        'id', 'sequence', 'controller', 'invoker', 'delegator', 'referenceId'
+        'id', 'sequence', 'controller', //, 'referenceId'
       ]);
       a.config.controller.should.equal(profile.id);
     });

--- a/test/mocha/20-profiles.js
+++ b/test/mocha/20-profiles.js
@@ -80,9 +80,8 @@ describe('profiles API', () => {
       agents.should.have.length(1);
       const [a] = agents;
       a.should.have.keys(['_id', 'id', 'controller', 'meta', 'config']);
-      // FIXME: keeping referenceId?
       a.config.should.have.keys([
-        'id', 'sequence', 'controller', //, 'referenceId'
+        'id', 'sequence', 'controller', 'referenceId'
       ]);
       a.config.controller.should.equal(profile.id);
     });

--- a/test/package.json
+++ b/test/package.json
@@ -18,7 +18,7 @@
     "bedrock-https-agent": "^2.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-kms": "^3.0.1",
-    "bedrock-kms-http": "^2.3.0",
+    "bedrock-kms-http": "digitalbazaar/bedrock-kms-http",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-mongodb": "^8.0.0",
     "bedrock-package-manager": "^1.0.1",

--- a/test/package.json
+++ b/test/package.json
@@ -18,7 +18,7 @@
     "bedrock-https-agent": "^2.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-kms": "^3.0.1",
-    "bedrock-kms-http": "digitalbazaar/bedrock-kms-http",
+    "bedrock-kms-http": "^4.0.0",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-mongodb": "^8.0.0",
     "bedrock-package-manager": "^1.0.1",

--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,7 @@
     "coverage-report": "nyc report"
   },
   "dependencies": {
-    "bedrock": "^3.1.1",
+    "bedrock": "^4.1.1",
     "bedrock-account": "^5.0.0",
     "bedrock-did-context": "^1.0.0",
     "bedrock-edv-storage": "^4.1.1",


### PR DESCRIPTION
### Changed
- **BREAKING**: Update to latest KMS keystore config data model. The data model
  no longer includes `invoker` or `delegator`.
- Use `KeystoreAgent` to update keystore configs vs using the `bedrock-kms` API
  directly.