### PR TITLE
Update did-method-key to 2.0.0 in order to use 2020 crypto suites.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-profile ChangeLog
 
+
+## 10.2.0 - TBD
+
+## Changed
+- Use did-method-key@2.0.0
+
 ## 10.1.0 - 2021-06-02
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-profile",
   "dependencies": {
-    "@digitalbazaar/did-method-key": "^1.0.0",
+    "@digitalbazaar/did-method-key": "^2.0.0",
     "@digitalbazaar/ed25519-signature-2018": "^2.0.1",
     "@digitalbazaar/ed25519-signature-2020": "^2.1.0",
     "@digitalbazaar/ed25519-verification-key-2018": "^3.1.1",


### PR DESCRIPTION
Updated `did-method-key` to version 2.0.0 so we now support `@digitalbazaar/ed25519-signature-2020` and `@digitalbazaar/ed25519-verification-key-2020` when using `didMethod: key` in profile creation.

p.s. this might be a breaking change, but I believe support for 2020 suites is intended as a feature in version 10.