### PR TITLE
Remove getKeystore()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # bedrock-profile ChangeLog
 
-## 13.0.0 - 2021-TBD
-
-### Changed
-- **BREAKING**: Update `getKeystore()` to take `capability` and
-  `invocationSigner` params in addition to `id`.
-
 ## 12.0.1 - 2021-09-21
 
 ### Changed

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -68,11 +68,6 @@ exports.updateKeystoreConfig = async ({keystoreAgent, keystoreConfig}) => {
   return result.config;
 };
 
-exports.getKeystore = ({id, capability, invocationSigner} = {}) => {
-  const kmsClient = new KmsClient({keystoreId: id, httpsAgent});
-  return kmsClient.getKeystore({capability, invocationSigner});
-};
-
 exports.getKeystoreAgent = ({capabilityAgent, keystoreId} = {}) => {
   const kmsClient = new KmsClient({keystoreId, httpsAgent});
   const keystoreAgent = new KeystoreAgent(


### PR DESCRIPTION
~~Updated getKeystore to work with latest  kmsClient.getKeystore() updates.~~

Removed unused `getKeystore()`.