### PR TITLE
Use utils.getCollection in profileMeters.

### DIFF
--- a/lib/profileMeters.js
+++ b/lib/profileMeters.js
@@ -4,6 +4,7 @@
 import * as bedrock from '@bedrock/core';
 import * as database from '@bedrock/mongodb';
 import assert from 'assert-plus';
+import {getCollection} from './utils.js';
 
 const {util: {BedrockError}} = bedrock;
 
@@ -43,7 +44,7 @@ export async function add({meter} = {}) {
     meter,
   };
   try {
-    const collection = database.collections['profile-meter'];
+    const collection = getCollection('profile-meter');
     const result = await collection.insertOne(record, database.writeOptions);
     record = result.ops[0];
   } catch(e) {
@@ -73,7 +74,7 @@ export async function get({id} = {}) {
 
   const query = {'meter.id': id};
   const projection = {_id: 0};
-  const collection = database.collections['profile-meter'];
+  const collection = getCollection('profile-meter');
 
   const record = await collection.findOne(query, {projection});
   if(!record) {
@@ -99,7 +100,7 @@ export async function remove({id} = {}) {
   assert.string(id, 'id');
 
   const query = {'meter.id': id};
-  const collection = database.collections['profile-meter'];
+  const collection = getCollection('profile-meter');
   await collection.deleteOne(query);
 }
 
@@ -120,7 +121,7 @@ export async function findByProfile({profileId} = {}) {
 
   const query = {'meter.profile': profileId};
   const projection = {_id: 0};
-  const collection = database.collections['profile-meter'];
+  const collection = getCollection('profile-meter');
 
   const meters = await collection.find(query, {projection}).toArray();
   return {meters};


### PR DESCRIPTION
This PR just re-uses the `utils.getCollection` method in `profileMeters.js` for consistency.
PR does not change functionality at all.
Feel free to disregard and or close if the `getCollection` function is being deprecated.