### PR TITLE
Add unit test for EDV query on core indices after zcap refresh

### DIFF
--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -78,6 +78,32 @@ export async function getEdvDocument({
   return doc.read();
 }
 
+export async function queryForEdvDocument({
+  equals, has, limit, edvClient, edvConfig, indexes,
+  kmsClient = new KmsClient({httpsAgent}),
+  profileSigner} = {}) {
+  const {hmac, keyAgreementKey} = edvConfig;
+  for(const index of indexes) {
+    edvClient.ensureIndex(index);
+  }
+  return edvClient.find({
+    equals, has, limit,
+    invocationSigner: profileSigner,
+    keyAgreementKey: new KeyAgreementKey({
+      id: keyAgreementKey.id,
+      type: keyAgreementKey.type,
+      invocationSigner: profileSigner,
+      kmsClient
+    }),
+    hmac: new Hmac({
+      id: hmac.id,
+      type: hmac.type,
+      invocationSigner: profileSigner,
+      kmsClient
+    })
+  });
+}
+
 export async function getUserEdvDocument({
   profileAgentRecord,
   zcaps = profileAgentRecord.profileAgent.zcaps,

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -81,7 +81,8 @@ export async function getEdvDocument({
 export async function queryForEdvDocument({
   equals, has, limit, edvClient, edvConfig, indexes,
   kmsClient = new KmsClient({httpsAgent}),
-  profileSigner} = {}) {
+  profileSigner
+} = {}) {
   const {hmac, keyAgreementKey} = edvConfig;
   for(const index of indexes) {
     edvClient.ensureIndex(index);


### PR DESCRIPTION
Adds a unit test the ensure that EDV queries are still possible on core indices after zcaps have been refreshed.

see #109, #108 